### PR TITLE
Project model detailed view addition

### DIFF
--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1,6 +1,9 @@
+import datetime
 from django.test import TestCase
 from django.urls import reverse
 from posts.models import Post
+from awards.models import Award
+from projects.models import Project
 
 # Create your tests here.
 class SimpleTests(TestCase):
@@ -42,3 +45,69 @@ class AboutPageViewTest(TestCase):
         resp = self.client.get(reverse('about'))
         self.assertEqual(resp.status_code, 200)
         self.assertTemplateUsed(resp, 'about.html')
+
+class AwardsPageViewTest(TestCase):
+    def setUp(self):
+        self.award = Award.objects.create(
+            date=datetime.datetime(2020, 5, 17),
+            title='A good title',
+            description='Nice description',
+        )
+        
+    def test_string_representation(self):
+        award = Award(title='A sample title')
+        self.assertEqual(str(award), award.title)
+        
+    def test_award_content(self):
+        self.assertEqual(f'{self.award.date}', str(datetime.datetime(2020, 5, 17)))
+        self.assertEqual(f'{self.award.title}', 'A good title')
+        self.assertEqual(f'{self.award.description}', 'Nice description')
+        
+    def test_view_url_exists_at_proper_location(self):
+        resp = self.client.get('/awards/')
+        self.assertEqual(resp.status_code, 200)
+        
+    def test_award_list_view(self):
+        response = self.client.get(reverse('awards'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Nice description')
+        self.assertTemplateUsed(response, 'award.html')
+
+class ProjectsPageViewTest(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            title='A good title',
+            abstract='A nice abstract',
+            description='Nice description',
+            code='https://www.google.com/',
+            deployment='https://www.google.com/',
+        )
+        
+    def test_view_url_exists_at_proper_location(self):
+        resp = self.client.get('/projects/')
+        self.assertEqual(resp.status_code, 200)
+    
+    def test_string_representation(self):
+        project = Project(title='A sample title')
+        self.assertEqual(str(project), project.title)
+    
+    def test_project_content(self):
+        self.assertEqual(f'{self.project.title}', 'A good title')
+        self.assertEqual(f'{self.project.abstract}', 'A nice abstract')
+        self.assertEqual(f'{self.project.description}', 'Nice description')
+        self.assertEqual(f'{self.project.code}', 'https://www.google.com/')
+        self.assertEqual(f'{self.project.deployment}', 'https://www.google.com/')
+        
+    def test_award_list_view(self):
+        response = self.client.get(reverse('projects'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'A nice abstract')
+        self.assertTemplateUsed(response, 'project.html')
+        
+    def test_post_detail_view(self):
+        response = self.client.get('/projects/1/')
+        no_response = self.client.get('/projects/100000/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(no_response.status_code, 404)
+        self.assertContains(response, 'A good title')
+        self.assertTemplateUsed(response, 'project_detail.html')

--- a/pages/urls.py
+++ b/pages/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import HomePageView, AboutPageView, AwardsPageView, ProjectsPageView
+from .views import HomePageView, AboutPageView, AwardsPageView, ProjectsPageView, ProjectsPageDetailView
 
 urlpatterns = [
     path('about/', AboutPageView.as_view(), name='about'),
     path('awards/', AwardsPageView.as_view(), name='awards'),
+    path('projects/<int:pk>/', ProjectsPageDetailView.as_view(), name='project_detail'),
     path('projects/', ProjectsPageView.as_view(), name='projects'),
     path('', HomePageView.as_view(), name='home'),
 ]

--- a/pages/views.py
+++ b/pages/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.views.generic import TemplateView, ListView
+from django.views.generic import TemplateView, ListView, DetailView
 from posts.models import Post
 from awards.models import Award
 from projects.models import Project
@@ -22,3 +22,7 @@ class ProjectsPageView(ListView):
     model = Project
     template_name = 'project.html'
     context_object_name = 'all_projects_list'
+    
+class ProjectsPageDetailView(DetailView):
+    model = Project
+    template_name = 'project_detail.html'

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -90,7 +90,6 @@ header h1 a {
     border-radius: 4px;
     cursor: pointer;
     opacity: 0.85;
-    transition-duration: 0.1s;
 }
 
 .project-entry-header-side button:hover {

--- a/templates/project.html
+++ b/templates/project.html
@@ -4,7 +4,7 @@
     {% for project in all_projects_list %}
         <div class="project-entry">
             <div class="project-entry-header">
-                <h2 class="project-entry-header-title">{{ project.title }}</h2>
+                <h2 class="project-entry-header-title"><a href="{% url 'project_detail' project.pk %}">{{ project.title }}</a></h2>
                 <div class="project-entry-header-side">
                     <button onclick="location.href='{{ project.deployment }}'" type="button">View Demo</button>
                     <button onclick="location.href='{{ project.deployment }}'" type="button">Source Code</button>

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <div class="project-entry">
+
+        <div class="project-entry-header">
+            <h2 class="project-entry-header-title">{{ project.title }}</h2>
+            <div class="project-entry-header-side">
+                <button onclick="location.href='{{ project.deployment }}'" type="button">View Demo</button>
+                <button onclick="location.href='{{ project.deployment }}'" type="button">Source Code</button>
+            </div>
+        </div>
+
+        <p>{{ project.description }}</p>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
Now it is possible to view details of a project individually like this.
![image](https://user-images.githubusercontent.com/60974969/118394142-7547ca00-b675-11eb-83cf-f18a88b4c728.png)

Test cases were added.

Test case will fail when more than 100,000 entries are added as per this line
`no_response = self.client.get('/projects/100000/')`
